### PR TITLE
Executable script and portability

### DIFF
--- a/minifloat.pl
+++ b/minifloat.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 $expsz  = 4;    # number of bits in the exponent
 $wordsz = 8;    # number of bits in the word


### PR DESCRIPTION
This PR makes two modifications to `minifloat.pl`:

1. Sets the executable bit, allowing it to be run directly on compatible operating systems.
2. Modifies the hashbang/shebang to use `env` rather than depending on Perl's binary being located in `/usr/bin`.